### PR TITLE
Rédaction d'un guide de contribution complet

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ L'information officielle sur la progression de l'épidémie en France est assez 
 
 L'objectif de ce dépôt est de consolider l'information officielle, et de la rendre disponible dans des formats ouverts et aisément réutilisables (JSON, CSV…).
 
-Inutile de perdre du temps à écrire des scrappers, à ce stade il est plus efficace de recopier les données, et d'indiquer la source.
+Inutile de perdre du temps à écrire des scrappers, à ce stade il est plus efficace de recopier les données à la main, et d'indiquer la source.
 
 ## Données résultantes
 
@@ -23,7 +23,19 @@ Les informations à la source sont au format PDF ou dans des communiqués au for
 
 Ces informations sont collectées et regroupées dans des fichiers YAML.
 
-1 fichier YAML par source et pas publication (donc par date).
+1 fichier YAML par source et par publication (donc par date).
+
+## Comment contribuer ?
+
+Les contributions se font via les fichiers YAML et non les fichiers CSV/JSON.
+
+Tâches :
+- créer les fichiers YAML manquants
+- vérifier les fichiers YAML existants
+
+Le plus simple pour contribuer est de copier un fichier YAML existant et de l'adapter avec les nouvelles données. Les données doivent être recopiées à la main depuis les différentes sources de données. Le fichier YAML doit être placé dans le bon répertoire et son nom doit être sous la forme YYYY-MM-DD.yaml (date de la données).
+
+Les sources de données (PDF ou site web) sont notées dans chaque fichier YAML et sont regroupées dans les fichiers CSV/JSON.
 
 ## Produire les fichiers JSON et CSV
 
@@ -48,6 +60,6 @@ npm run build
 
 ## Licence
 
-Données sous Licence Ouverte (sauf mention du contraire)
+Données sous Licence Ouverte (sauf mention contraire)
 
 Code sous licence MIT

--- a/README.md
+++ b/README.md
@@ -27,15 +27,51 @@ Ces informations sont collectées et regroupées dans des fichiers YAML.
 
 ## Comment contribuer ?
 
-Les contributions se font via les fichiers YAML et non les fichiers CSV/JSON.
+Les contributions se font via les fichiers YAML et non dans le fichier de sortie(CSV/JSON).
 
 Tâches :
 - créer les fichiers YAML manquants
-- vérifier les fichiers YAML existants
+- vérifier les [pull requests](https://github.com/opencovid19-fr/data/pulls)
 
-Le plus simple pour contribuer est de copier un fichier YAML existant et de l'adapter avec les nouvelles données. Les données doivent être recopiées à la main depuis les différentes sources de données. Le fichier YAML doit être placé dans le bon répertoire et son nom doit être sous la forme YYYY-MM-DD.yaml (date de la données).
+Le plus simple pour contribuer est de copier un fichier YAML existant et de l'adapter avec les nouvelles données. Les données doivent être recopiées à la main depuis les différentes sources de données. Le fichier YAML doit être placé dans le bon répertoire et son nom doit être sous la forme YYYY-MM-DD.yaml (date du bulletin).
 
-Les sources de données (PDF ou site web) sont notées dans chaque fichier YAML et sont regroupées dans les fichiers CSV/JSON.
+Les sources de données (PDF ou site web) sont notées dans chaque fichier YAML. Si vous cherchez des sources de données, les sources actuelles sont regroupées dans le fichier de sortie (CSV/JSON).
+
+### Comment compléter les fichiers YAML
+Consigne générale : le nombre d'espaces en début de ligne est très important, ainsi que la position des tirets `-`, soyez vigilant en complétant les fichiers.
+
+Voici un exemple de bloc YAML pour une entête de fichier :
+```
+date: 2020-03-10
+source:
+  nom: nom-de-la-source-de-donnees
+  url: https://site.web/lien-vers-le-bulletin.pdf
+  archive: https://web.archive.org/web/XXXXXX/https://site.web/lien-vers-le-bulletin
+```
+Le fichier YAML doit commencer par la date du bulletin, suivi pour un bloc source. Il convient de mettre le nom et l'url de la source (de préférence un bulletin PDF ou une page web). Il est possible d'ajouter `archive:` est de coller un lien vers une page web archivée sur https://web.archive.org, en effet certains bulletins web sont écrasés chaque jour sur la même url.
+
+
+Voici un exemple de bloc YAML pour une région ou un département:
+```
+  nom: region-ou-departement-exemple
+  code: Exemple
+  casConfirmes: 500
+  gueris: 40
+  deces: 10
+  hospitalises: 10
+  reanimation: 5
+  victimes:
+    - age: 85
+      date: 2020-03-10
+      sexe: homme
+    - sexe: femme
+      date: 2020-03-10
+    - date: 2020-03-10
+```
+
+Les champs `casConfirmes`, `gueris` et `deces` comptabilisent le total par catégorie depuis le début de la crise Covid-19. Par contre, les champs `hospitalises` et `reanimation` donnent le nombre de patient par catégorie à l'instant de l'édition du bulletin d'information, ces 2 chiffres peuvent bien sûr évoluer à la hausse ou à la baisse.
+
+Le bloc `victimes` détaille les informations du bulletin concernant les personnes décédés (et non les personnes contaminées). Attention ce champ ne comptabilise pas toutes les victimes depuis le début de la crise, mais uniquement les victimes annoncées dans le bulletin. Pour chaque victime, on ajoute un tiret `-`, puis les informations sur la personne. Si aucune information, ajoutez la date du décès `- date: 2020-03-10`. Si vous disposez de plus d'information, ajoutez un tiret `-` par victime puis toutes les informations disponibles `age`, `sexe` et/ou `date` (cf. exemple ci-dessus)
 
 ## Produire les fichiers JSON et CSV
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Les sources de données (PDF ou site web) sont notées dans chaque fichier YAML.
 ### Comment compléter les fichiers YAML
 Consigne générale : le nombre d'espaces en début de ligne est très important, ainsi que la position des tirets `-`, soyez vigilant en complétant les fichiers.
 
+#### Entête de fichier YAML
 Voici un exemple de bloc YAML pour une entête de fichier :
-```
+```yaml
 date: 2020-03-10
 source:
   nom: nom-de-la-source-de-donnees
@@ -50,13 +51,13 @@ source:
 ```
 Le fichier YAML doit commencer par la date du bulletin, suivi pour un bloc source. Il convient de mettre le nom et l'url de la source (de préférence un bulletin PDF ou une page web). Il est possible d'ajouter `archive:` est de coller un lien vers une page web archivée sur https://web.archive.org, en effet certains bulletins web sont écrasés chaque jour sur la même url.
 
-
+#### Bloc YAML par région ou département 
 Voici un exemple de bloc YAML pour une région ou un département:
-```
+```yaml
   nom: region-ou-departement-exemple
   code: Exemple
   casConfirmes: 500
-  gueris: 40
+  gueris: 40 # valeur copiée du fichier YAML précédent
   deces: 10
   hospitalises: 10
   reanimation: 5
@@ -71,7 +72,14 @@ Voici un exemple de bloc YAML pour une région ou un département:
 
 Les champs `casConfirmes`, `gueris` et `deces` comptabilisent le total par catégorie depuis le début de la crise Covid-19. Par contre, les champs `hospitalises` et `reanimation` donnent le nombre de patient par catégorie à l'instant de l'édition du bulletin d'information, ces 2 chiffres peuvent bien sûr évoluer à la hausse ou à la baisse.
 
+Notez qu'il est possible si besoin d'ajouter des commentaires en fin de ligne en utilisant le caractère `#`
+
 Le bloc `victimes` détaille les informations du bulletin concernant les personnes décédés (et non les personnes contaminées). Attention ce champ ne comptabilise pas toutes les victimes depuis le début de la crise, mais uniquement les victimes annoncées dans le bulletin. Pour chaque victime, on ajoute un tiret `-`, puis les informations sur la personne. Si aucune information, ajoutez la date du décès `- date: 2020-03-10`. Si vous disposez de plus d'information, ajoutez un tiret `-` par victime puis toutes les informations disponibles `age`, `sexe` et/ou `date` (cf. exemple ci-dessus)
+
+Notez qu'il est possible que certains bulletins soient érronés. Dans ce cas, corrigez le fichier YAML sur lequel l'erratum s'applique. Il convient de noter via un commentaire `#` la raison de la différence entre le nombre indiqué dans le YAML et le nombre indiqué dans sa source. Exemple :
+```yaml
+  casConfirmes: 29 # Erratum du bulletin 13/03 : 1 cas compté en double. La valeur 30 du bulletin du 12/03 est donc erronée
+```
 
 ## Produire les fichiers JSON et CSV
 


### PR DESCRIPTION
Bonjour @jdesboeufs, je viens de rédiger un guide de contribution complet afin d'harmoniser les contributions.

En effet, il y a quelques variantes entre les différents fichiers YAML, notamment sur les dates. Dans certains fichiers, les dates sont placées entre quotes `"`. Bon je ne pense pas que ce soit gênant car ton outil doit être capable de filtrer tout ça ?

Bonne journée.