### PR TITLE
consolidating data from the ARS Nouvelle Aquitaine using their xlsx table (taken down from their website after March 12th)

### DIFF
--- a/agences-regionales-sante/nouvelle-aquitaine/2020-03-03.yaml
+++ b/agences-regionales-sante/nouvelle-aquitaine/2020-03-03.yaml
@@ -30,7 +30,7 @@ donneesDepartementales:
     casConfirmes: 1
   - nom: Lot-et-Garonne
     code: DEP-47
-    casConfirmes: 0
+    casConfirmes: 1
   - nom: Pyrénées-Atlantiques
     code: DEP-64
     casConfirmes: 0

--- a/agences-regionales-sante/nouvelle-aquitaine/2020-03-04.yaml
+++ b/agences-regionales-sante/nouvelle-aquitaine/2020-03-04.yaml
@@ -14,6 +14,7 @@ donneesDepartementales:
   - nom: Charente-Maritime
     code: DEP-17
     casConfirmes: 1
+    gueris: 1
   - nom: Corrèze
     code: DEP-19
     casConfirmes: 0
@@ -31,7 +32,7 @@ donneesDepartementales:
     casConfirmes: 1
   - nom: Lot-et-Garonne
     code: DEP-47
-    casConfirmes: 0
+    casConfirmes: 1
   - nom: Pyrénées-Atlantiques
     code: DEP-64
     casConfirmes: 1

--- a/agences-regionales-sante/nouvelle-aquitaine/2020-03-05.yaml
+++ b/agences-regionales-sante/nouvelle-aquitaine/2020-03-05.yaml
@@ -14,6 +14,7 @@ donneesDepartementales:
   - nom: Charente-Maritime
     code: DEP-17
     casConfirmes: 1
+    gueris: 1
   - nom: Corrèze
     code: DEP-19
     casConfirmes: 0
@@ -31,7 +32,7 @@ donneesDepartementales:
     casConfirmes: 1
   - nom: Lot-et-Garonne
     code: DEP-47
-    casConfirmes: 2
+    casConfirmes: 3
   - nom: Pyrénées-Atlantiques
     code: DEP-64
     casConfirmes: 1

--- a/agences-regionales-sante/nouvelle-aquitaine/2020-03-06.yaml
+++ b/agences-regionales-sante/nouvelle-aquitaine/2020-03-06.yaml
@@ -15,6 +15,7 @@ donneesDepartementales:
   - nom: Charente-Maritime
     code: DEP-17
     casConfirmes: 2
+    gueris: 1
   - nom: Corrèze
     code: DEP-19
     casConfirmes: 0
@@ -32,10 +33,11 @@ donneesDepartementales:
     casConfirmes: 1
   - nom: Lot-et-Garonne
     code: DEP-47
-    casConfirmes: 2
+    casConfirmes: 3
   - nom: Pyrénées-Atlantiques
     code: DEP-64
     casConfirmes: 1
+    gueris: 1
   - nom: Deux-Sèvres
     code: DEP-79
     casConfirmes: 1

--- a/agences-regionales-sante/nouvelle-aquitaine/2020-03-07.yaml
+++ b/agences-regionales-sante/nouvelle-aquitaine/2020-03-07.yaml
@@ -14,6 +14,7 @@ donneesDepartementales:
   - nom: Charente-Maritime
     code: DEP-17
     casConfirmes: 2
+    gueris: 1
   - nom: Corrèze
     code: DEP-19
     casConfirmes: 0
@@ -31,10 +32,11 @@ donneesDepartementales:
     casConfirmes: 1
   - nom: Lot-et-Garonne
     code: DEP-47
-    casConfirmes: 5
+    casConfirmes: 6
   - nom: Pyrénées-Atlantiques
     code: DEP-64
     casConfirmes: 2
+    gueris: 1
   - nom: Deux-Sèvres
     code: DEP-79
     casConfirmes: 1

--- a/agences-regionales-sante/nouvelle-aquitaine/2020-03-08.yaml
+++ b/agences-regionales-sante/nouvelle-aquitaine/2020-03-08.yaml
@@ -14,6 +14,7 @@ donneesDepartementales:
   - nom: Charente-Maritime
     code: DEP-17
     casConfirmes: 7
+    gueris: 1
   - nom: Corrèze
     code: DEP-19
     casConfirmes: 1
@@ -31,10 +32,11 @@ donneesDepartementales:
     casConfirmes: 1
   - nom: Lot-et-Garonne
     code: DEP-47
-    casConfirmes: 10
+    casConfirmes: 11
   - nom: Pyrénées-Atlantiques
     code: DEP-64
     casConfirmes: 2
+    gueris: 1
   - nom: Deux-Sèvres
     code: DEP-79
     casConfirmes: 1

--- a/agences-regionales-sante/nouvelle-aquitaine/2020-03-09.yaml
+++ b/agences-regionales-sante/nouvelle-aquitaine/2020-03-09.yaml
@@ -14,6 +14,7 @@ donneesDepartementales:
   - nom: Charente-Maritime
     code: DEP-17
     casConfirmes: 7
+    gueris: 1
   - nom: Corrèze
     code: DEP-19
     casConfirmes: 2
@@ -31,10 +32,11 @@ donneesDepartementales:
     casConfirmes: 1
   - nom: Lot-et-Garonne
     code: DEP-47
-    casConfirmes: 15
+    casConfirmes: 16
   - nom: Pyrénées-Atlantiques
     code: DEP-64
     casConfirmes: 2
+    gueris: 1
   - nom: Deux-Sèvres
     code: DEP-79
     casConfirmes: 1

--- a/agences-regionales-sante/nouvelle-aquitaine/2020-03-10.yaml
+++ b/agences-regionales-sante/nouvelle-aquitaine/2020-03-10.yaml
@@ -14,6 +14,7 @@ donneesDepartementales:
   - nom: Charente-Maritime
     code: DEP-17
     casConfirmes: 13
+    gueris: 1
   - nom: Corrèze
     code: DEP-19
     casConfirmes: 2
@@ -31,10 +32,11 @@ donneesDepartementales:
     casConfirmes: 1
   - nom: Lot-et-Garonne
     code: DEP-47
-    casConfirmes: 22
+    casConfirmes: 23
   - nom: Pyrénées-Atlantiques
     code: DEP-64
     casConfirmes: 2
+    gueris: 1
   - nom: Deux-Sèvres
     code: DEP-79
     casConfirmes: 1

--- a/agences-regionales-sante/nouvelle-aquitaine/2020-03-11.yaml
+++ b/agences-regionales-sante/nouvelle-aquitaine/2020-03-11.yaml
@@ -14,6 +14,7 @@ donneesDepartementales:
   - nom: Charente-Maritime
     code: DEP-17
     casConfirmes: 20
+    gueris: 1
   - nom: Corrèze
     code: DEP-19
     casConfirmes: 4
@@ -35,6 +36,7 @@ donneesDepartementales:
   - nom: Pyrénées-Atlantiques
     code: DEP-64
     casConfirmes: 1
+    gueris: 1
   - nom: Deux-Sèvres
     code: DEP-79
     casConfirmes: 1

--- a/agences-regionales-sante/nouvelle-aquitaine/2020-03-12.yaml
+++ b/agences-regionales-sante/nouvelle-aquitaine/2020-03-12.yaml
@@ -14,6 +14,7 @@ donneesDepartementales:
   - nom: Charente-Maritime
     code: DEP-17
     casConfirmes: 20
+    gueris: 1
   - nom: Corrèze
     code: DEP-19
     casConfirmes: 5
@@ -35,6 +36,7 @@ donneesDepartementales:
   - nom: Pyrénées-Atlantiques
     code: DEP-64
     casConfirmes: 7
+    gueris: 1
   - nom: Deux-Sèvres
     code: DEP-79
     casConfirmes: 1

--- a/agences-regionales-sante/nouvelle-aquitaine/2020-03-13.yaml
+++ b/agences-regionales-sante/nouvelle-aquitaine/2020-03-13.yaml
@@ -14,6 +14,7 @@ donneesDepartementales:
   - nom: Charente-Maritime
     code: DEP-17
     casConfirmes: 23
+    gueris: 1
   - nom: Corrèze
     code: DEP-19
     casConfirmes: 5
@@ -35,6 +36,7 @@ donneesDepartementales:
   - nom: Pyrénées-Atlantiques
     code: DEP-64
     casConfirmes: 7
+    gueris: 1
   - nom: Deux-Sèvres
     code: DEP-79
     casConfirmes: 2

--- a/agences-regionales-sante/nouvelle-aquitaine/2020-03-14.yaml
+++ b/agences-regionales-sante/nouvelle-aquitaine/2020-03-14.yaml
@@ -14,6 +14,7 @@ donneesDepartementales:
   - nom: Charente-Maritime
     code: DEP-17
     casConfirmes: 25
+    gueris: 1
   - nom: Corrèze
     code: DEP-19
     casConfirmes: 5
@@ -35,6 +36,7 @@ donneesDepartementales:
   - nom: Pyrénées-Atlantiques
     code: DEP-64
     casConfirmes: 13
+    gueris: 1
   - nom: Deux-Sèvres
     code: DEP-79
     casConfirmes: 3

--- a/agences-regionales-sante/nouvelle-aquitaine/2020-03-15.yaml
+++ b/agences-regionales-sante/nouvelle-aquitaine/2020-03-15.yaml
@@ -15,6 +15,7 @@ donneesDepartementales:
   - nom: Charente-Maritime
     code: DEP-17
     casConfirmes: 25
+    gueris: 1
   - nom: Corrèze
     code: DEP-19
     casConfirmes: 5
@@ -40,6 +41,7 @@ donneesDepartementales:
   - nom: Pyrénées-Atlantiques
     code: DEP-64
     casConfirmes: 18 # Parmi les cas confirmés le 12/03 qui étaient en attente de géolocalisation, 1 se situe dans les Pyrénées-Atlantiques.
+    gueris: 1
   - nom: Deux-Sèvres
     code: DEP-79
     casConfirmes: 3

--- a/agences-regionales-sante/nouvelle-aquitaine/README.md
+++ b/agences-regionales-sante/nouvelle-aquitaine/README.md
@@ -4,3 +4,7 @@ L'ARS Nouvelle-Aquitaine ne donne pas des chiffres en valeurs absolues mais en d
 C'est rattrapé partiellement dans le bulletin du 2020-03-13 où l'ARS Nouvelle Aquitaine livre des chiffres absolus dans certaines régions.
 
 N.B: il y a quand même des incohérences possibles entre les données régionales et départementales de par la présence d'erreurs de rattachement au niveau des département (les erratums des bulletins indiqués dans les fichiers yaml).
+
+Jusqu'au 2020-12-03, l'ARS Nouvelle Aquitaine maintenait à jour un fichier .xlsx sur sa page dédiée au Covid-19, comptabilisant les cas incidents jusqu'au 11 mars minuit. D'après ce fichier, une correction apportée est la confirmation d'1 cas le 3 mars dans le 47, déclaré tardivement.  
+Par ailleurs, les 2 guéris à l'échelle départementale sont maintenant indiqués dans chaque fichier .yaml
+ 


### PR DESCRIPTION
Jusqu'au 2020-12-03, l'ARS Nouvelle Aquitaine maintenait à jour un fichier .xlsx sur sa page dédiée au Covid-19, comptabilisant les cas incidents jusqu'au 11 mars minuit. D'après ce fichier, une correction apportée est la confirmation d'1 cas le 3 mars dans le 47, déclaré tardivement. 

Par ailleurs, les 2 guéris à l'échelle départementale sont maintenant indiqués dans chaque fichier .yaml

 
