### PR TITLE
[ADDED] Ajout du 16/03 pour la Corse

### DIFF
--- a/agences-regionales-sante/corse/2020-03-16.yaml
+++ b/agences-regionales-sante/corse/2020-03-16.yaml
@@ -1,0 +1,26 @@
+date: 2020-03-16
+source:
+  nom: ARS Corse
+  url: https://twitter.com/ARSCORSE1/status/1239595508013969409
+  archive: https://web.archive.org/web/20200315111623/https://www.corse.ars.sante.fr/coronavirus-covid-19-informations-utiles
+donneesRegionales:
+  nom: Corse
+  code: REG-94
+  casConfirmes: 126
+  gueris: 0
+  reanimation: 2
+  deces: 7
+donneesDepartementales:
+  - nom: Corse du Sud
+    code: DEP-2A
+    casConfirmes: 102
+    reanimation: 2
+    deces: 7
+    victimes:
+      - age: 80
+        date: 2020-03-13
+        date: 2020-03-13
+  - nom: Haute-Corse
+    code: DEP-2B
+    casConfirmes: 24
+    deces: 0

--- a/agences-regionales-sante/corse/2020-03-16.yaml
+++ b/agences-regionales-sante/corse/2020-03-16.yaml
@@ -17,8 +17,7 @@ donneesDepartementales:
     reanimation: 2
     deces: 7
     victimes:
-      - age: 80
-        date: 2020-03-13
+      - date: 2020-03-13
       - date: 2020-03-13
   - nom: Haute-Corse
     code: DEP-2B

--- a/agences-regionales-sante/corse/2020-03-16.yaml
+++ b/agences-regionales-sante/corse/2020-03-16.yaml
@@ -2,7 +2,7 @@ date: 2020-03-16
 source:
   nom: ARS Corse
   url: https://twitter.com/ARSCORSE1/status/1239595508013969409
-  archive: https://web.archive.org/web/20200315111623/https://www.corse.ars.sante.fr/coronavirus-covid-19-informations-utiles
+  archive: https://web.archive.org/web/20200316215601/https://www.corse.ars.sante.fr/coronavirus-covid-19-informations-utiles
 donneesRegionales:
   nom: Corse
   code: REG-94

--- a/agences-regionales-sante/corse/2020-03-16.yaml
+++ b/agences-regionales-sante/corse/2020-03-16.yaml
@@ -19,7 +19,7 @@ donneesDepartementales:
     victimes:
       - age: 80
         date: 2020-03-13
-        date: 2020-03-13
+      - date: 2020-03-13
   - nom: Haute-Corse
     code: DEP-2B
     casConfirmes: 24


### PR DESCRIPTION
Ajout de la journée du 16/03 pour la Corse.
A savoir que les 2 personnes décédées sont annoncées à "plus de 80 ans" et non "80 ans". 
J'ai pour le moment mis ces 2 entrées à 80 ans en age. 
A voir si on maintient ces 2 personnes pour cet âge là ou si on retire juste l'entrée victime pour le moment pour elles.