### PR TITLE
Ajout des données historiques lperez31/coronavirus-france-dataset

### DIFF
--- a/build.js
+++ b/build.js
@@ -9,7 +9,8 @@ const Papa = require('papaparse')
 const sources = [
   'agences-regionales-sante',
   'sante-publique-france',
-  'prefectures'
+  'prefectures',
+  'lperez31-historical-data'
 ]
 
 const distPath = join(__dirname, 'dist')

--- a/lperez31-historical-data/auvergne-rhone-alpes/2020-02-08.yaml
+++ b/lperez31-historical-data/auvergne-rhone-alpes/2020-02-08.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-08'
+donneesDepartementales:
+- casConfirmes: 6
+  code: DEP-74
+  nom: Haute-Savoie
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/auvergne-rhone-alpes/2020-02-25.yaml
+++ b/lperez31-historical-data/auvergne-rhone-alpes/2020-02-25.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-25'
+donneesDepartementales:
+- casConfirmes: 7
+  code: DEP-74
+  nom: Haute-Savoie
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/auvergne-rhone-alpes/2020-03-04.yaml
+++ b/lperez31-historical-data/auvergne-rhone-alpes/2020-03-04.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-04'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-26
+  nom: Drôme
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/auvergne-rhone-alpes/2020-03-05.yaml
+++ b/lperez31-historical-data/auvergne-rhone-alpes/2020-03-05.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-05'
+donneesDepartementales:
+- casConfirmes: 3
+  code: DEP-63
+  nom: Puy-de-Dôme
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/auvergne-rhone-alpes/2020-03-07.yaml
+++ b/lperez31-historical-data/auvergne-rhone-alpes/2020-03-07.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-07'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-38
+  nom: Isère
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bourgogne-franche-comte/2020-02-26.yaml
+++ b/lperez31-historical-data/bourgogne-franche-comte/2020-02-26.yaml
@@ -1,0 +1,11 @@
+date: '2020-02-26'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-25
+  nom: Doubs
+- casConfirmes: 2
+  code: DEP-90
+  nom: Territoire de Belfort
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bourgogne-franche-comte/2020-02-27.yaml
+++ b/lperez31-historical-data/bourgogne-franche-comte/2020-02-27.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-27'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-21
+  nom: Côte-d'Or
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bourgogne-franche-comte/2020-02-28.yaml
+++ b/lperez31-historical-data/bourgogne-franche-comte/2020-02-28.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-28'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-21
+  nom: Côte-d'Or
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bourgogne-franche-comte/2020-03-01.yaml
+++ b/lperez31-historical-data/bourgogne-franche-comte/2020-03-01.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-01'
+donneesDepartementales:
+- casConfirmes: 6
+  code: DEP-25
+  nom: Doubs
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bourgogne-franche-comte/2020-03-03.yaml
+++ b/lperez31-historical-data/bourgogne-franche-comte/2020-03-03.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-03'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-71
+  nom: Saône-et-Loire
+- casConfirmes: 6
+  code: DEP-90
+  nom: Territoire de Belfort
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bourgogne-franche-comte/2020-03-04.yaml
+++ b/lperez31-historical-data/bourgogne-franche-comte/2020-03-04.yaml
@@ -1,0 +1,14 @@
+date: '2020-03-04'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-70
+  nom: Haute-Saône
+- casConfirmes: 2
+  code: DEP-71
+  nom: Saône-et-Loire
+- casConfirmes: 7
+  code: DEP-90
+  nom: Territoire de Belfort
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bourgogne-franche-comte/2020-03-05.yaml
+++ b/lperez31-historical-data/bourgogne-franche-comte/2020-03-05.yaml
@@ -1,0 +1,14 @@
+date: '2020-03-05'
+donneesDepartementales:
+- casConfirmes: 17
+  code: DEP-25
+  nom: Doubs
+- casConfirmes: 5
+  code: DEP-71
+  nom: Saône-et-Loire
+- casConfirmes: 18
+  code: DEP-90
+  nom: Territoire de Belfort
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bourgogne-franche-comte/2020-03-06.yaml
+++ b/lperez31-historical-data/bourgogne-franche-comte/2020-03-06.yaml
@@ -1,0 +1,26 @@
+date: '2020-03-06'
+donneesDepartementales:
+- casConfirmes: 5
+  code: DEP-21
+  nom: Côte-d'Or
+- casConfirmes: 30
+  code: DEP-25
+  nom: Doubs
+- casConfirmes: 2
+  code: DEP-39
+  nom: Jura
+- casConfirmes: 3
+  code: DEP-70
+  nom: Haute-Saône
+- casConfirmes: 8
+  code: DEP-71
+  nom: Saône-et-Loire
+- casConfirmes: 2
+  code: DEP-89
+  nom: Yonne
+- casConfirmes: 30
+  code: DEP-90
+  nom: Territoire de Belfort
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bourgogne-franche-comte/2020-03-07.yaml
+++ b/lperez31-historical-data/bourgogne-franche-comte/2020-03-07.yaml
@@ -1,0 +1,23 @@
+date: '2020-03-07'
+donneesDepartementales:
+- casConfirmes: 7
+  code: DEP-21
+  nom: Côte-d'Or
+- casConfirmes: 39
+  code: DEP-25
+  nom: Doubs
+- casConfirmes: 4
+  code: DEP-39
+  nom: Jura
+- casConfirmes: 5
+  code: DEP-70
+  nom: Haute-Saône
+- casConfirmes: 10
+  code: DEP-71
+  nom: Saône-et-Loire
+- casConfirmes: 38
+  code: DEP-90
+  nom: Territoire de Belfort
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bourgogne-franche-comte/2020-03-08.yaml
+++ b/lperez31-historical-data/bourgogne-franche-comte/2020-03-08.yaml
@@ -1,0 +1,14 @@
+date: '2020-03-08'
+donneesDepartementales:
+- casConfirmes: 41
+  code: DEP-25
+  nom: Doubs
+- casConfirmes: 4
+  code: DEP-89
+  nom: Yonne
+- casConfirmes: 41
+  code: DEP-90
+  nom: Territoire de Belfort
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bourgogne-franche-comte/2020-03-09.yaml
+++ b/lperez31-historical-data/bourgogne-franche-comte/2020-03-09.yaml
@@ -1,0 +1,14 @@
+date: '2020-03-09'
+donneesDepartementales:
+- casConfirmes: 44
+  code: DEP-25
+  nom: Doubs
+- casConfirmes: 11
+  code: DEP-71
+  nom: Saône-et-Loire
+- casConfirmes: 44
+  code: DEP-90
+  nom: Territoire de Belfort
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bourgogne-franche-comte/2020-03-10.yaml
+++ b/lperez31-historical-data/bourgogne-franche-comte/2020-03-10.yaml
@@ -1,0 +1,26 @@
+date: '2020-03-10'
+donneesDepartementales:
+- casConfirmes: 9
+  code: DEP-21
+  nom: Côte-d'Or
+- casConfirmes: 52
+  code: DEP-25
+  nom: Doubs
+- casConfirmes: 6
+  code: DEP-39
+  nom: Jura
+- casConfirmes: 7
+  code: DEP-70
+  nom: Haute-Saône
+- casConfirmes: 13
+  code: DEP-71
+  nom: Saône-et-Loire
+- casConfirmes: 6
+  code: DEP-89
+  nom: Yonne
+- casConfirmes: 52
+  code: DEP-90
+  nom: Territoire de Belfort
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bourgogne-franche-comte/2020-03-11.yaml
+++ b/lperez31-historical-data/bourgogne-franche-comte/2020-03-11.yaml
@@ -1,0 +1,20 @@
+date: '2020-03-11'
+donneesDepartementales:
+- casConfirmes: 59
+  code: DEP-25
+  nom: Doubs
+- casConfirmes: 7
+  code: DEP-39
+  nom: Jura
+- casConfirmes: 9
+  code: DEP-70
+  nom: Haute-Saône
+- casConfirmes: 7
+  code: DEP-89
+  nom: Yonne
+- casConfirmes: 58
+  code: DEP-90
+  nom: Territoire de Belfort
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bretagne/2020-02-27.yaml
+++ b/lperez31-historical-data/bretagne/2020-02-27.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-27'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-29
+  nom: Finistère
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bretagne/2020-02-28.yaml
+++ b/lperez31-historical-data/bretagne/2020-02-28.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-28'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-29
+  nom: Finistère
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bretagne/2020-02-29.yaml
+++ b/lperez31-historical-data/bretagne/2020-02-29.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-29'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-35
+  nom: Ille-et-Vilaine
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bretagne/2020-03-01.yaml
+++ b/lperez31-historical-data/bretagne/2020-03-01.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-01'
+donneesDepartementales:
+- casConfirmes: 4
+  code: DEP-35
+  nom: Ille-et-Vilaine
+- casConfirmes: 9
+  code: DEP-56
+  nom: Morbihan
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/bretagne/2020-03-02.yaml
+++ b/lperez31-historical-data/bretagne/2020-03-02.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-02'
+donneesDepartementales:
+- casConfirmes: 3
+  code: DEP-29
+  nom: Finistère
+- casConfirmes: 12
+  code: DEP-56
+  nom: Morbihan
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/centre-val-de-loire/2020-03-04.yaml
+++ b/lperez31-historical-data/centre-val-de-loire/2020-03-04.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-04'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-28
+  nom: Eure-et-Loir
+- casConfirmes: 1
+  code: DEP-37
+  nom: Indre-et-Loire
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/centre-val-de-loire/2020-03-05.yaml
+++ b/lperez31-historical-data/centre-val-de-loire/2020-03-05.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-05'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-45
+  nom: Loiret
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/centre-val-de-loire/2020-03-06.yaml
+++ b/lperez31-historical-data/centre-val-de-loire/2020-03-06.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-06'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-37
+  nom: Indre-et-Loire
+- casConfirmes: 4
+  code: DEP-45
+  nom: Loiret
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/centre-val-de-loire/2020-03-08.yaml
+++ b/lperez31-historical-data/centre-val-de-loire/2020-03-08.yaml
@@ -1,0 +1,14 @@
+date: '2020-03-08'
+donneesDepartementales:
+- casConfirmes: 5
+  code: DEP-28
+  nom: Eure-et-Loir
+- casConfirmes: 5
+  code: DEP-37
+  nom: Indre-et-Loire
+- casConfirmes: 7
+  code: DEP-45
+  nom: Loiret
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/centre-val-de-loire/2020-03-11.yaml
+++ b/lperez31-historical-data/centre-val-de-loire/2020-03-11.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-11'
+donneesDepartementales:
+- casConfirmes: 6
+  code: DEP-37
+  nom: Indre-et-Loire
+- casConfirmes: 9
+  code: DEP-45
+  nom: Loiret
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/collectivites-outre-mer/2020-03-01.yaml
+++ b/lperez31-historical-data/collectivites-outre-mer/2020-03-01.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-01'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-977
+  nom: Saint-Barthélemy
+- casConfirmes: 2
+  code: DEP-978
+  nom: Saint-Martin
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/corse/2020-03-05.yaml
+++ b/lperez31-historical-data/corse/2020-03-05.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-05'
+donneesDepartementales:
+- casConfirmes: 3
+  code: DEP-2A
+  nom: Corse-du-Sud
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/corse/2020-03-06.yaml
+++ b/lperez31-historical-data/corse/2020-03-06.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-06'
+donneesDepartementales:
+- casConfirmes: 5
+  code: DEP-2A
+  nom: Corse-du-Sud
+- casConfirmes: 2
+  code: DEP-2B
+  nom: Haute-Corse
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/corse/2020-03-07.yaml
+++ b/lperez31-historical-data/corse/2020-03-07.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-07'
+donneesDepartementales:
+- casConfirmes: 12
+  code: DEP-2A
+  nom: Corse-du-Sud
+- casConfirmes: 5
+  code: DEP-2B
+  nom: Haute-Corse
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/corse/2020-03-09.yaml
+++ b/lperez31-historical-data/corse/2020-03-09.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-09'
+donneesDepartementales:
+- casConfirmes: 23
+  code: DEP-2A
+  nom: Corse-du-Sud
+- casConfirmes: 6
+  code: DEP-2B
+  nom: Haute-Corse
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/corse/2020-03-10.yaml
+++ b/lperez31-historical-data/corse/2020-03-10.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-10'
+donneesDepartementales:
+- casConfirmes: 27
+  code: DEP-2A
+  nom: Corse-du-Sud
+- casConfirmes: 7
+  code: DEP-2B
+  nom: Haute-Corse
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/corse/2020-03-11.yaml
+++ b/lperez31-historical-data/corse/2020-03-11.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-11'
+donneesDepartementales:
+- casConfirmes: 40
+  code: DEP-2A
+  nom: Corse-du-Sud
+- casConfirmes: 8
+  code: DEP-2B
+  nom: Haute-Corse
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/corse/2020-03-12.yaml
+++ b/lperez31-historical-data/corse/2020-03-12.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-12'
+donneesDepartementales:
+- casConfirmes: 50
+  code: DEP-2A
+  nom: Corse-du-Sud
+- casConfirmes: 10
+  code: DEP-2B
+  nom: Haute-Corse
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/grand-est/2020-02-27.yaml
+++ b/lperez31-historical-data/grand-est/2020-02-27.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-27'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-67
+  nom: Bas-Rhin
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/grand-est/2020-03-06.yaml
+++ b/lperez31-historical-data/grand-est/2020-03-06.yaml
@@ -1,0 +1,20 @@
+date: '2020-03-06'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-51
+  nom: Marne
+- casConfirmes: 1
+  code: DEP-55
+  nom: Meuse
+- casConfirmes: 1
+  code: DEP-57
+  nom: Moselle
+- casConfirmes: 80
+  code: DEP-68
+  nom: Haut-Rhin
+- casConfirmes: 2
+  code: DEP-88
+  nom: Vosges
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/grand-est/2020-03-07.yaml
+++ b/lperez31-historical-data/grand-est/2020-03-07.yaml
@@ -1,0 +1,14 @@
+date: '2020-03-07'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-52
+  nom: Haute-Marne
+- casConfirmes: 8
+  code: DEP-57
+  nom: Moselle
+- casConfirmes: 46
+  code: DEP-67
+  nom: Bas-Rhin
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/guadeloupe/2020-03-13.yaml
+++ b/lperez31-historical-data/guadeloupe/2020-03-13.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-13'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-971
+  nom: Guadeloupe
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/guyane/2020-03-04.yaml
+++ b/lperez31-historical-data/guyane/2020-03-04.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-04'
+donneesDepartementales:
+- casConfirmes: 5
+  code: DEP-973
+  nom: Guyane
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/guyane/2020-03-13.yaml
+++ b/lperez31-historical-data/guyane/2020-03-13.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-13'
+donneesDepartementales:
+- casConfirmes: 6
+  code: DEP-973
+  nom: Guyane
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/hauts-de-france/2020-02-26.yaml
+++ b/lperez31-historical-data/hauts-de-france/2020-02-26.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-26'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-60
+  nom: Oise
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/hauts-de-france/2020-02-29.yaml
+++ b/lperez31-historical-data/hauts-de-france/2020-02-29.yaml
@@ -1,0 +1,11 @@
+date: '2020-02-29'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-02
+  nom: Aisne
+- casConfirmes: 3
+  code: DEP-60
+  nom: Oise
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/hauts-de-france/2020-03-01.yaml
+++ b/lperez31-historical-data/hauts-de-france/2020-03-01.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-01'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-02
+  nom: Aisne
+- casConfirmes: 1
+  code: DEP-62
+  nom: Pas-de-Calais
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/hauts-de-france/2020-03-02.yaml
+++ b/lperez31-historical-data/hauts-de-france/2020-03-02.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-02'
+donneesDepartementales:
+- casConfirmes: 4
+  code: DEP-02
+  nom: Aisne
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/hauts-de-france/2020-03-03.yaml
+++ b/lperez31-historical-data/hauts-de-france/2020-03-03.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-03'
+donneesDepartementales:
+- casConfirmes: 8
+  code: DEP-02
+  nom: Aisne
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/hauts-de-france/2020-03-04.yaml
+++ b/lperez31-historical-data/hauts-de-france/2020-03-04.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-04'
+donneesDepartementales:
+- casConfirmes: 12
+  code: DEP-02
+  nom: Aisne
+- casConfirmes: 1
+  code: DEP-59
+  nom: Nord
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/hauts-de-france/2020-03-05.yaml
+++ b/lperez31-historical-data/hauts-de-france/2020-03-05.yaml
@@ -1,0 +1,14 @@
+date: '2020-03-05'
+donneesDepartementales:
+- casConfirmes: 14
+  code: DEP-02
+  nom: Aisne
+- casConfirmes: 6
+  code: DEP-60
+  nom: Oise
+- casConfirmes: 2
+  code: DEP-80
+  nom: Somme
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/hauts-de-france/2020-03-06.yaml
+++ b/lperez31-historical-data/hauts-de-france/2020-03-06.yaml
@@ -1,0 +1,14 @@
+date: '2020-03-06'
+donneesDepartementales:
+- casConfirmes: 20
+  code: DEP-02
+  nom: Aisne
+- casConfirmes: 4
+  code: DEP-59
+  nom: Nord
+- casConfirmes: 3
+  code: DEP-80
+  nom: Somme
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/hauts-de-france/2020-03-07.yaml
+++ b/lperez31-historical-data/hauts-de-france/2020-03-07.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-07'
+donneesDepartementales:
+- casConfirmes: 7
+  code: DEP-60
+  nom: Oise
+- casConfirmes: 3
+  code: DEP-62
+  nom: Pas-de-Calais
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/hauts-de-france/2020-03-08.yaml
+++ b/lperez31-historical-data/hauts-de-france/2020-03-08.yaml
@@ -1,0 +1,14 @@
+date: '2020-03-08'
+donneesDepartementales:
+- casConfirmes: 21
+  code: DEP-02
+  nom: Aisne
+- casConfirmes: 5
+  code: DEP-59
+  nom: Nord
+- casConfirmes: 9
+  code: DEP-60
+  nom: Oise
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/hauts-de-france/2020-03-09.yaml
+++ b/lperez31-historical-data/hauts-de-france/2020-03-09.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-09'
+donneesDepartementales:
+- casConfirmes: 28
+  code: DEP-02
+  nom: Aisne
+- casConfirmes: 4
+  code: DEP-62
+  nom: Pas-de-Calais
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/la-reunion/2020-03-11.yaml
+++ b/lperez31-historical-data/la-reunion/2020-03-11.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-11'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-974
+  nom: La Réunion
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/la-reunion/2020-03-12.yaml
+++ b/lperez31-historical-data/la-reunion/2020-03-12.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-12'
+donneesDepartementales:
+- casConfirmes: 4
+  code: DEP-974
+  nom: La Réunion
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/la-reunion/2020-03-13.yaml
+++ b/lperez31-historical-data/la-reunion/2020-03-13.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-13'
+donneesDepartementales:
+- casConfirmes: 5
+  code: DEP-974
+  nom: La Réunion
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/martinique/2020-03-05.yaml
+++ b/lperez31-historical-data/martinique/2020-03-05.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-05'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-972
+  nom: Martinique
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/martinique/2020-03-09.yaml
+++ b/lperez31-historical-data/martinique/2020-03-09.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-09'
+donneesDepartementales:
+- casConfirmes: 3
+  code: DEP-972
+  nom: Martinique
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/martinique/2020-03-11.yaml
+++ b/lperez31-historical-data/martinique/2020-03-11.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-11'
+donneesDepartementales:
+- casConfirmes: 4
+  code: DEP-972
+  nom: Martinique
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/martinique/2020-03-12.yaml
+++ b/lperez31-historical-data/martinique/2020-03-12.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-12'
+donneesDepartementales:
+- casConfirmes: 6
+  code: DEP-972
+  nom: Martinique
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/normandie/2020-02-28.yaml
+++ b/lperez31-historical-data/normandie/2020-02-28.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-28'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-76
+  nom: Seine-Maritime
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/normandie/2020-03-04.yaml
+++ b/lperez31-historical-data/normandie/2020-03-04.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-04'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-27
+  nom: Eure
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/normandie/2020-03-05.yaml
+++ b/lperez31-historical-data/normandie/2020-03-05.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-05'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-14
+  nom: Calvados
+- casConfirmes: 3
+  code: DEP-50
+  nom: Manche
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/normandie/2020-03-06.yaml
+++ b/lperez31-historical-data/normandie/2020-03-06.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-06'
+donneesDepartementales:
+- casConfirmes: 6
+  code: DEP-50
+  nom: Manche
+- casConfirmes: 2
+  code: DEP-76
+  nom: Seine-Maritime
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/nouvelle-aquitaine/2020-02-24.yaml
+++ b/lperez31-historical-data/nouvelle-aquitaine/2020-02-24.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-24'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-33
+  nom: Gironde
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/nouvelle-aquitaine/2020-02-28.yaml
+++ b/lperez31-historical-data/nouvelle-aquitaine/2020-02-28.yaml
@@ -1,0 +1,14 @@
+date: '2020-02-28'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-17
+  nom: Charente-Maritime
+- casConfirmes: 2
+  code: DEP-33
+  nom: Gironde
+- casConfirmes: 1
+  code: DEP-40
+  nom: Landes
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/nouvelle-aquitaine/2020-03-03.yaml
+++ b/lperez31-historical-data/nouvelle-aquitaine/2020-03-03.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-03'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-64
+  nom: Pyrénées-Atlantiques
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/nouvelle-aquitaine/2020-03-05.yaml
+++ b/lperez31-historical-data/nouvelle-aquitaine/2020-03-05.yaml
@@ -1,0 +1,11 @@
+date: '2020-03-05'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-47
+  nom: Lot-et-Garonne
+- casConfirmes: 1
+  code: DEP-79
+  nom: Deux-Sèvres
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/nouvelle-aquitaine/2020-03-06.yaml
+++ b/lperez31-historical-data/nouvelle-aquitaine/2020-03-06.yaml
@@ -1,0 +1,14 @@
+date: '2020-03-06'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-16
+  nom: Charente
+- casConfirmes: 2
+  code: DEP-17
+  nom: Charente-Maritime
+- casConfirmes: 1
+  code: DEP-24
+  nom: Dordogne
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/nouvelle-aquitaine/2020-03-07.yaml
+++ b/lperez31-historical-data/nouvelle-aquitaine/2020-03-07.yaml
@@ -1,0 +1,14 @@
+date: '2020-03-07'
+donneesDepartementales:
+- casConfirmes: 3
+  code: DEP-33
+  nom: Gironde
+- casConfirmes: 5
+  code: DEP-47
+  nom: Lot-et-Garonne
+- casConfirmes: 2
+  code: DEP-64
+  nom: Pyrénées-Atlantiques
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/nouvelle-aquitaine/2020-03-08.yaml
+++ b/lperez31-historical-data/nouvelle-aquitaine/2020-03-08.yaml
@@ -1,0 +1,20 @@
+date: '2020-03-08'
+donneesDepartementales:
+- casConfirmes: 7
+  code: DEP-17
+  nom: Charente-Maritime
+- casConfirmes: 1
+  code: DEP-19
+  nom: Corrèze
+- casConfirmes: 4
+  code: DEP-33
+  nom: Gironde
+- casConfirmes: 10
+  code: DEP-47
+  nom: Lot-et-Garonne
+- casConfirmes: 1
+  code: DEP-86
+  nom: Vienne
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/nouvelle-aquitaine/2020-03-09.yaml
+++ b/lperez31-historical-data/nouvelle-aquitaine/2020-03-09.yaml
@@ -1,0 +1,17 @@
+date: '2020-03-09'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-19
+  nom: Corrèze
+- casConfirmes: 3
+  code: DEP-24
+  nom: Dordogne
+- casConfirmes: 15
+  code: DEP-47
+  nom: Lot-et-Garonne
+- casConfirmes: 3
+  code: DEP-86
+  nom: Vienne
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/nouvelle-aquitaine/2020-03-10.yaml
+++ b/lperez31-historical-data/nouvelle-aquitaine/2020-03-10.yaml
@@ -1,0 +1,17 @@
+date: '2020-03-10'
+donneesDepartementales:
+- casConfirmes: 13
+  code: DEP-17
+  nom: Charente-Maritime
+- casConfirmes: 5
+  code: DEP-33
+  nom: Gironde
+- casConfirmes: 22
+  code: DEP-47
+  nom: Lot-et-Garonne
+- casConfirmes: 4
+  code: DEP-86
+  nom: Vienne
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/nouvelle-aquitaine/2020-03-11.yaml
+++ b/lperez31-historical-data/nouvelle-aquitaine/2020-03-11.yaml
@@ -1,0 +1,29 @@
+date: '2020-03-11'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-16
+  nom: Charente
+- casConfirmes: 20
+  code: DEP-17
+  nom: Charente-Maritime
+- casConfirmes: 4
+  code: DEP-19
+  nom: Corrèze
+- casConfirmes: 7
+  code: DEP-33
+  nom: Gironde
+- casConfirmes: 23
+  code: DEP-47
+  nom: Lot-et-Garonne
+- casConfirmes: 3
+  code: DEP-64
+  nom: Pyrénées-Atlantiques
+- casConfirmes: 6
+  code: DEP-86
+  nom: Vienne
+- casConfirmes: 1
+  code: DEP-87
+  nom: Haute-Vienne
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/nouvelle-aquitaine/2020-03-12.yaml
+++ b/lperez31-historical-data/nouvelle-aquitaine/2020-03-12.yaml
@@ -1,0 +1,26 @@
+date: '2020-03-12'
+donneesDepartementales:
+- casConfirmes: 3
+  code: DEP-16
+  nom: Charente
+- casConfirmes: 5
+  code: DEP-19
+  nom: Corrèze
+- casConfirmes: 5
+  code: DEP-24
+  nom: Dordogne
+- casConfirmes: 9
+  code: DEP-33
+  nom: Gironde
+- casConfirmes: 3
+  code: DEP-40
+  nom: Landes
+- casConfirmes: 25
+  code: DEP-47
+  nom: Lot-et-Garonne
+- casConfirmes: 9
+  code: DEP-64
+  nom: Pyrénées-Atlantiques
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/occitanie/2020-01-27.yaml
+++ b/lperez31-historical-data/occitanie/2020-01-27.yaml
@@ -1,0 +1,8 @@
+date: '2020-01-27'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-34
+  nom: Hérault
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/occitanie/2020-02-28.yaml
+++ b/lperez31-historical-data/occitanie/2020-02-28.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-28'
+donneesDepartementales:
+- casConfirmes: 3
+  code: DEP-34
+  nom: Hérault
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/occitanie/2020-03-01.yaml
+++ b/lperez31-historical-data/occitanie/2020-03-01.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-01'
+donneesDepartementales:
+- casConfirmes: 5
+  code: DEP-34
+  nom: Hérault
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/occitanie/2020-03-02.yaml
+++ b/lperez31-historical-data/occitanie/2020-03-02.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-02'
+donneesDepartementales:
+- casConfirmes: 6
+  code: DEP-34
+  nom: Hérault
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/occitanie/2020-03-03.yaml
+++ b/lperez31-historical-data/occitanie/2020-03-03.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-03'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-30
+  nom: Gard
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/occitanie/2020-03-04.yaml
+++ b/lperez31-historical-data/occitanie/2020-03-04.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-04'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-12
+  nom: Aveyron
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/occitanie/2020-03-05.yaml
+++ b/lperez31-historical-data/occitanie/2020-03-05.yaml
@@ -1,0 +1,14 @@
+date: '2020-03-05'
+donneesDepartementales:
+- casConfirmes: 4
+  code: DEP-12
+  nom: Aveyron
+- casConfirmes: 1
+  code: DEP-31
+  nom: Haute-Garonne
+- casConfirmes: 9
+  code: DEP-34
+  nom: Hérault
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/occitanie/2020-03-06.yaml
+++ b/lperez31-historical-data/occitanie/2020-03-06.yaml
@@ -1,0 +1,23 @@
+date: '2020-03-06'
+donneesDepartementales:
+- casConfirmes: 3
+  code: DEP-30
+  nom: Gard
+- casConfirmes: 2
+  code: DEP-31
+  nom: Haute-Garonne
+- casConfirmes: 11
+  code: DEP-34
+  nom: Hérault
+- casConfirmes: 1
+  code: DEP-46
+  nom: Lot
+- casConfirmes: 2
+  code: DEP-81
+  nom: Tarn
+- casConfirmes: 3
+  code: DEP-82
+  nom: Tarn-et-Garonne
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/occitanie/2020-03-08.yaml
+++ b/lperez31-historical-data/occitanie/2020-03-08.yaml
@@ -1,0 +1,17 @@
+date: '2020-03-08'
+donneesDepartementales:
+- casConfirmes: 8
+  code: DEP-11
+  nom: Aude
+- casConfirmes: 8
+  code: DEP-12
+  nom: Aveyron
+- casConfirmes: 1
+  code: DEP-32
+  nom: Gers
+- casConfirmes: 18
+  code: DEP-34
+  nom: Hérault
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/occitanie/2020-03-10.yaml
+++ b/lperez31-historical-data/occitanie/2020-03-10.yaml
@@ -1,0 +1,23 @@
+date: '2020-03-10'
+donneesDepartementales:
+- casConfirmes: 22
+  code: DEP-11
+  nom: Aude
+- casConfirmes: 9
+  code: DEP-12
+  nom: Aveyron
+- casConfirmes: 6
+  code: DEP-30
+  nom: Gard
+- casConfirmes: 40
+  code: DEP-34
+  nom: Hérault
+- casConfirmes: 3
+  code: DEP-81
+  nom: Tarn
+- casConfirmes: 4
+  code: DEP-82
+  nom: Tarn-et-Garonne
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/pays-de-la-loire/2020-02-27.yaml
+++ b/lperez31-historical-data/pays-de-la-loire/2020-02-27.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-27'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-44
+  nom: Loire-Atlantique
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/pays-de-la-loire/2020-02-28.yaml
+++ b/lperez31-historical-data/pays-de-la-loire/2020-02-28.yaml
@@ -1,0 +1,11 @@
+date: '2020-02-28'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-49
+  nom: Maine-et-Loire
+- casConfirmes: 1
+  code: DEP-53
+  nom: Mayenne
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/pays-de-la-loire/2020-03-01.yaml
+++ b/lperez31-historical-data/pays-de-la-loire/2020-03-01.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-01'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-72
+  nom: Sarthe
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/pays-de-la-loire/2020-03-02.yaml
+++ b/lperez31-historical-data/pays-de-la-loire/2020-03-02.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-02'
+donneesDepartementales:
+- casConfirmes: 2
+  code: DEP-44
+  nom: Loire-Atlantique
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/pays-de-la-loire/2020-03-03.yaml
+++ b/lperez31-historical-data/pays-de-la-loire/2020-03-03.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-03'
+donneesDepartementales:
+- casConfirmes: 3
+  code: DEP-44
+  nom: Loire-Atlantique
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/pays-de-la-loire/2020-03-04.yaml
+++ b/lperez31-historical-data/pays-de-la-loire/2020-03-04.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-04'
+donneesDepartementales:
+- casConfirmes: 4
+  code: DEP-44
+  nom: Loire-Atlantique
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/pays-de-la-loire/2020-03-06.yaml
+++ b/lperez31-historical-data/pays-de-la-loire/2020-03-06.yaml
@@ -1,0 +1,17 @@
+date: '2020-03-06'
+donneesDepartementales:
+- casConfirmes: 5
+  code: DEP-44
+  nom: Loire-Atlantique
+- casConfirmes: 3
+  code: DEP-49
+  nom: Maine-et-Loire
+- casConfirmes: 3
+  code: DEP-72
+  nom: Sarthe
+- casConfirmes: 1
+  code: DEP-85
+  nom: Vendée
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/pays-de-la-loire/2020-03-07.yaml
+++ b/lperez31-historical-data/pays-de-la-loire/2020-03-07.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-07'
+donneesDepartementales:
+- casConfirmes: 4
+  code: DEP-49
+  nom: Maine-et-Loire
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/pays-de-la-loire/2020-03-08.yaml
+++ b/lperez31-historical-data/pays-de-la-loire/2020-03-08.yaml
@@ -1,0 +1,17 @@
+date: '2020-03-08'
+donneesDepartementales:
+- casConfirmes: 8
+  code: DEP-44
+  nom: Loire-Atlantique
+- casConfirmes: 7
+  code: DEP-49
+  nom: Maine-et-Loire
+- casConfirmes: 5
+  code: DEP-72
+  nom: Sarthe
+- casConfirmes: 4
+  code: DEP-85
+  nom: Vendée
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/pays-de-la-loire/2020-03-09.yaml
+++ b/lperez31-historical-data/pays-de-la-loire/2020-03-09.yaml
@@ -1,0 +1,8 @@
+date: '2020-03-09'
+donneesDepartementales:
+- casConfirmes: 9
+  code: DEP-44
+  nom: Loire-Atlantique
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset

--- a/lperez31-historical-data/provence-alpes-cote-d-azur/2020-02-28.yaml
+++ b/lperez31-historical-data/provence-alpes-cote-d-azur/2020-02-28.yaml
@@ -1,0 +1,8 @@
+date: '2020-02-28'
+donneesDepartementales:
+- casConfirmes: 1
+  code: DEP-06
+  nom: Alpes-Maritimes
+source:
+  nom: Coronavirus-France-Dataset
+  url: https://github.com/lperez31/coronavirus-france-dataset


### PR DESCRIPTION
Cette PR propose d'ajouter des données plus anciennes issues du projet https://github.com/lperez31/coronavirus-france-dataset.
Elles couvrent essentiellement le début de l'épidémie en France.

La traçabilité des données est à rechercher sur le dépôt distant.

Au fur et à mesure des saisies, les contributeurs pourront supprimer ces fichiers.

Qu'en pensez-vous ?