### PR TITLE
Ajout du 19/03 pour la Guadeloupe

### DIFF
--- a/agences-regionales-sante/guadeloupe/2020-03-19.yaml
+++ b/agences-regionales-sante/guadeloupe/2020-03-19.yaml
@@ -1,0 +1,17 @@
+date: 2020-03-19
+source:
+  nom: ARS Guadeloupe
+  url: https://www.guadeloupe.ars.sante.fr/system/files/2020-03/19032020%20point%20de%20situation%20Coronavirus.pdf
+  archive: http://web.archive.org/web/20200319203031/https://www.guadeloupe.ars.sante.fr/system/files/2020-03/19032020%20point%20de%20situation%20Coronavirus.pdf
+donneesRegionales:
+  nom: Guadeloupe
+  code: REG-01
+  casConfirmes: 45
+  hospitalises: 8
+  reanimation: 3
+donneesDepartementales:
+  - nom: Guadeloupe
+    code: DEP-971
+    casConfirmes: 45
+    hospitalises: 8
+    reanimation: 3


### PR DESCRIPTION
Voir si on ajout la journée du 18 basé sur les chiffres du jour étant donné qu'il donne l'évolution par rapport à la veille.
Pas de document en date du 18 par contre..