### PR TITLE
Suppression des deces 06/13/83 pour le 17/03 (ARS PACA)

### DIFF
--- a/agences-regionales-sante/provence-alpes-cote-dazur/2020-03-17.yaml
+++ b/agences-regionales-sante/provence-alpes-cote-dazur/2020-03-17.yaml
@@ -22,15 +22,12 @@ donneesDepartementales:
   - nom: Alpes-Maritimes
     code: DEP-06
     casConfirmes: 104
-    deces: 1
   - nom: Bouches-du-Rhône
     code: DEP-13
     casConfirmes: 237
-    deces: 2
   - nom: Var
     code: DEP-83
     casConfirmes: 95
-    deces: 1
   - nom: Vaucluse
     code: DEP-84
     casConfirmes: 13


### PR DESCRIPTION
#161 
- Suppression des deces 06/13/83 (car dans la depeche ARS ils ne sont pas attribues au departement specifiquement)
- J'ai garle les deces 04/05/84 a 0