### PR TITLE
Ajout IDF 19/03 et 15/03

### DIFF
--- a/agences-regionales-sante/ile-de-france/2020-03-15.yaml
+++ b/agences-regionales-sante/ile-de-france/2020-03-15.yaml
@@ -1,0 +1,10 @@
+date: "2020-03-15"
+source:
+  nom: Santé Publique France
+  url: https://www.santepubliquefrance.fr/maladies-et-traumatismes/maladies-et-infections-respiratoires/infection-a-coronavirus/documents/bulletin-national/covid-19-point-epidemiologique-du-15-mars-2020 # Voir PDF "Situation au 15 mars 2020 à minuit"
+donneesRegionales:
+  nom: Ile-de-France
+  code: REG-11
+  casConfirmes: 1846
+  reanimation: 206 # +51
+  deces: 16

--- a/agences-regionales-sante/ile-de-france/2020-03-19.yaml
+++ b/agences-regionales-sante/ile-de-france/2020-03-19.yaml
@@ -1,0 +1,8 @@
+date: "2020-03-19"
+source:
+  nom: Santé Publique France
+  url: https://www.santepubliquefrance.fr/maladies-et-traumatismes/maladies-et-infections-respiratoires/infection-a-coronavirus/articles/infection-au-nouveau-coronavirus-sars-cov-2-covid-19-france-et-monde
+donneesRegionales:
+  nom: Ile-de-France
+  code: REG-11
+  casConfirmes: 3384


### PR DESCRIPTION
Sources Santé Publique France:

- 2020-03-19 :
cf. section _Nombre de cas rapportés par région au 19/03/2020 à 15h_ : https://www.santepubliquefrance.fr/maladies-et-traumatismes/maladies-et-infections-respiratoires/infection-a-coronavirus/articles/infection-au-nouveau-coronavirus-sars-cov-2-covid-19-france-et-monde

- 2020-03-15 :
cf. PDF point épidémiologique du 15 mars 2020
https://www.santepubliquefrance.fr/maladies-et-traumatismes/maladies-et-infections-respiratoires/infection-a-coronavirus/documents/bulletin-national/covid-19-point-epidemiologique-du-15-mars-2020

Questions :

- Pour le 2020-03-15, j'ai fait un cumul sur le nombre de `reanimation`, par rapport à la valeur du fichier `2020-03-15.yaml`. Est-ce ok ?

- Les données du fichier `2020-03-17.yaml` me semblent étranges par rapport à celles données dans le PDF du point du 15 mars publié par la Santé Publique.