### PR TITLE
ARS Grand-Est : casConfirmes -> hospitalises pour 19/03 et 20/03

### DIFF
--- a/agences-regionales-sante/grand-est/2020-03-19.yaml
+++ b/agences-regionales-sante/grand-est/2020-03-19.yaml
@@ -6,7 +6,7 @@ source:
 donneesRegionales:
   nom: Grand-Est
   code: REG-44
-  casConfirmes: 1169
+  hospitalises: 1169
   reanimation: 300
   gueris: 213
   deces: 93 # +32 depuis mardi (dernier bulletin)

--- a/agences-regionales-sante/grand-est/2020-03-20.yaml
+++ b/agences-regionales-sante/grand-est/2020-03-20.yaml
@@ -6,7 +6,7 @@ source:
 donneesRegionales:
   nom: Grand-Est
   code: REG-44
-  casConfirmes: 1551
+  hospitalises: 1551
   reanimation: 352 # près de 9% ont moins de 60 ans
   gueris: 284
   deces: 105


### PR DESCRIPTION
L'ARS Grand-Est publie depuis le 19 mars le nombre de personnes hospitalisées et non plus le nombre de cas confirmés.

Pdf du 17 mars, avant le changement : https://www.grand-est.ars.sante.fr/system/files/2020-03/CPCoronavirus_GrandEst170320.pdf
Pdf du 19 mars, après le changement : https://www.grand-est.ars.sante.fr/system/files/2020-03/CPCoronavirus_GrandEst_190320.pdf