### PR TITLE
Suppression doublon

### DIFF
--- a/agences-regionales-sante/grand-est/2020-03-07.yaml
+++ b/agences-regionales-sante/grand-est/2020-03-07.yaml
@@ -1,9 +1,0 @@
-date: "2020-03-06"
-source:
-  nom: ARS Grand-Est
-  url: https://www.grand-est.ars.sante.fr/system/files/2020-03/20200306_CP_MesuresCoronavirusHautRhin.pdf
-donneesRegionales:
-  nom: Grand-Est
-  code: REG-44
-  casConfirmes: 81
-  deces: 0


### PR DESCRIPTION
Dans l'ARS Grand-Est, 2020-03-07.yaml est un doublon de 2020-03-06.yaml.