### PR TITLE
PACA: 2020-03-22

### DIFF
--- a/agences-regionales-sante/provence-alpes-cote-dazur/2020-03-22.yaml
+++ b/agences-regionales-sante/provence-alpes-cote-dazur/2020-03-22.yaml
@@ -1,0 +1,30 @@
+date: "2020-03-22"
+source:
+  nom: ARS Provence-Alpes-Côte d’Azur
+  url: https://www.facebook.com/story.php?story_fbid=3163580943675065&id=122014131165110
+  archive: https://web.archive.org/web/20200323105113/https://www.facebook.com/story.php?story_fbid=3163580943675065&id=122014131165110
+donneesRegionales:
+  nom: Provence-Alpes-Côte d’Azur
+  code: REG-93
+  casConfirmes: 1316
+  reanimation: 85
+  deces: 15
+donneesDepartementales:
+  - nom: Alpes-de-Haute-Provence
+    code: DEP-04
+    casConfirmes: 22
+  - nom: Hautes-Alpes
+    code: DEP-05
+    casConfirmes: 42
+  - nom: Alpes-Maritimes
+    code: DEP-06
+    casConfirmes: 194
+  - nom: Bouches-du-Rhône
+    code: DEP-13
+    casConfirmes: 827
+  - nom: Var
+    code: DEP-83
+    casConfirmes: 186
+  - nom: Vaucluse
+    code: DEP-84
+    casConfirmes: 45


### PR DESCRIPTION
https://github.com/opencovid19-fr/data/issues/273

[The report](https://www.facebook.com/story.php?story_fbid=3163580943675065&id=122014131165110):

Point de situation du 22 mars :
1316 personnes testées positives #Covid19 en #Paca

🔘22 dans les Alpes-de-Haute-Provence
🔘 42 personnes dans les Hautes-Alpes ;
🔘194 personnes dans les Alpes-Maritimes ;
🔘827 personnes dans les Bouches-du-Rhône ;
🔘186 personnes dans le Var ;
🔘45 personnes dans le Vaucluse.

Parmi elles :
⚫️85 personnes en réanimation ;
⚫️15 personnes décédées.