### PR TITLE
Intégration des données hospitalières de Santé publique France

### DIFF
--- a/build.js
+++ b/build.js
@@ -6,6 +6,7 @@ const glob = require('glob')
 const {ensureArray, readYamlFile, outputCsv} = require('./lib/util')
 const validate = require('./lib/validate')
 const {jsonToCsvRow} = require('./lib/csv')
+const {loadData} = require('./lib/data-sources/spf')
 
 const sources = [
   'agences-regionales-sante',
@@ -82,6 +83,7 @@ async function main() {
     .map(flattenSourcesData)
     .flatten()
     .filter(r => 'casConfirmes' in r || 'deces' in r || 'reanimation' in r || 'hospitalises' in r || 'gueris' in r)
+    .concat(await loadData())
     .sortBy(r => `${r.date}-${r.code}`)
     .value()
 

--- a/lib/data-sources/spf.js
+++ b/lib/data-sources/spf.js
@@ -1,0 +1,63 @@
+const {join} = require('path')
+const Papa = require('papaparse')
+const {keyBy, chain} = require('lodash')
+const {readFile} = require('fs-extra')
+const departements = require('@etalab/decoupage-administratif/data/departements.json')
+const regions = require('@etalab/decoupage-administratif/data/regions.json')
+
+const departementsIndex = keyBy(departements, 'code')
+const regionsIndex = keyBy(regions, 'code')
+
+const spfDataSourcePath = join(__dirname, '..', '..', 'data-sources', 'sante-publique-france')
+const covidHospitPath = join(spfDataSourcePath, 'covid_hospit.csv')
+
+async function loadData() {
+  const fileContent = await readFile(covidHospitPath, {encoding: 'utf8'})
+  const rows = Papa.parse(fileContent, {header: true}).data
+
+  const departementsData = rows.filter(r => r.sexe === '0').map(r => {
+    return {
+      code: `DEP-${r.dep}`,
+      nom: departementsIndex[r.dep].nom,
+      date: r.jour,
+      hospitalises: Number.parseInt(r.hosp, 10),
+      reanimation: Number.parseInt(r.rea, 10),
+      deces: Number.parseInt(r.dc, 10),
+      gueris: Number.parseInt(r.rad, 10)
+    }
+  })
+
+  const regionsData = chain(rows)
+    .filter(r => r.sexe === '0')
+    .groupBy(r => `${r.jour}-${departementsIndex[r.dep].region}`)
+    .map(regionRows => {
+      const firstRow = regionRows[0]
+      const region = regionsIndex[departementsIndex[firstRow.dep].region]
+
+      return regionRows.reduce((region, row) => {
+        region.hospitalises += Number.parseInt(row.hosp, 10)
+        region.reanimation += Number.parseInt(row.rea, 10)
+        region.deces += Number.parseInt(row.dc, 10)
+        region.gueris += Number.parseInt(row.rad, 10)
+
+        return region
+      }, {
+        code: `REG-${region.code}`,
+        nom: region.nom,
+        date: firstRow.jour,
+        hospitalises: 0,
+        reanimation: 0,
+        deces: 0,
+        gueris: 0
+      })
+    })
+    .value()
+
+  return [...departementsData, ...regionsData].map(row => ({
+    ...row,
+    source: {nom: 'Santé publique France Data'},
+    sourceType: 'sante-publique-france-data'
+  }))
+}
+
+module.exports = {loadData}

--- a/lib/data-sources/spf.js
+++ b/lib/data-sources/spf.js
@@ -57,7 +57,33 @@ async function loadData() {
     })
     .value()
 
-  return [...departementsData, ...regionsData]
+  const franceData = chain(regionsData)
+    .groupBy('date')
+    .map(regionsRows => {
+      const firstRow = regionsRows[0]
+
+      return regionsRows.reduce((france, region) => {
+        france.hospitalises += region.hospitalises
+        france.reanimation += region.reanimation
+        france.deces += region.deces
+        france.gueris += region.gueris
+
+        return france
+      }, {
+        code: 'FRA',
+        nom: 'France',
+        date: firstRow.date,
+        hospitalises: 0,
+        reanimation: 0,
+        deces: 0,
+        gueris: 0,
+        source: {nom: 'OpenCOVID19-fr'},
+        sourceType: 'opencovid19-fr'
+      })
+    })
+    .value()
+
+  return [...departementsData, ...regionsData, ...franceData]
 }
 
 module.exports = {loadData}

--- a/lib/data-sources/spf.js
+++ b/lib/data-sources/spf.js
@@ -23,7 +23,9 @@ async function loadData() {
       hospitalises: Number.parseInt(r.hosp, 10),
       reanimation: Number.parseInt(r.rea, 10),
       deces: Number.parseInt(r.dc, 10),
-      gueris: Number.parseInt(r.rad, 10)
+      gueris: Number.parseInt(r.rad, 10),
+      source: {nom: 'Santé publique France Data'},
+      sourceType: 'sante-publique-france-data'
     }
   })
 
@@ -48,16 +50,14 @@ async function loadData() {
         hospitalises: 0,
         reanimation: 0,
         deces: 0,
-        gueris: 0
+        gueris: 0,
+        source: {nom: 'OpenCOVID19-fr'},
+        sourceType: 'opencovid19-fr'
       })
     })
     .value()
 
-  return [...departementsData, ...regionsData].map(row => ({
-    ...row,
-    source: {nom: 'Santé publique France Data'},
-    sourceType: 'sante-publique-france-data'
-  }))
+  return [...departementsData, ...regionsData]
 }
 
 module.exports = {loadData}


### PR DESCRIPTION
Cette PR permet d'intégrer les données du CSV des données hospitalières de SPF dans le JSON et le CSV de sortie.

Les données présentes dans le fichier sont sourcées `Santé publique France Data`.
Les données calculées (régions et France) sont sourcées `OpenCOVID19-fr`

Ces nouvelles données s'ajoutent à celles des ARS et des bulletins SPF.
Je rappelle que les fichiers de sortie sont des fichiers agrégées, et ne sont pas consolidés.
La consolidation est à l'appréciation de l'utilisation.

Pour l'instant le fichier source est dans le dépôt, le temps qu'il soit mis à disposition de façon automatisée.