### PR TITLE
ADD ARS Centre Val de Loire 24/03

### DIFF
--- a/agences-regionales-sante/centre-val-de-loire/2020-03-24.yaml
+++ b/agences-regionales-sante/centre-val-de-loire/2020-03-24.yaml
@@ -1,0 +1,36 @@
+date: 2020-03-24
+source:
+  nom: ARS Centre-Val de Loire
+  url: https://www.centre-val-de-loire.ars.sante.fr/system/files/2020-03/2020-03-24-bulletin%20information%20COVID-19_0.pdf
+  archive: https://web.archive.org/web/20200324220044/https://www.centre-val-de-loire.ars.sante.fr/system/files/2020-03/2020-03-24-bulletin%20information%20COVID-19_0.pdf
+donneesRegionales:
+  nom: Centre-Val de Loire
+  code: REG-24
+  casConfirmes: 450
+  deces: 8
+  reanimation: 44
+donneesDepartementales:
+  - nom: Cher
+    code: DEP-18
+    casConfirmes: 20
+    deces: 0
+  - nom: Eure-et-Loir
+    code: DEP-28
+    casConfirmes: 87
+    deces: 3
+  - nom: Indre
+    code: DEP-36
+    casConfirmes: 50
+    deces: 2
+  - nom: Indre-et-Loire
+    code: DEP-37
+    casConfirmes: 86
+    deces: 2
+  - nom: Loir-et-Cher
+    code: DEP-41
+    casConfirmes: 37
+    deces: 0
+  - nom: Loiret
+    code: DEP-45
+    casConfirmes: 170
+    deces: 1


### PR DESCRIPTION
Sur cette journée,
on peut constater un décès en moins pour le Loiret mais un en plus pour l'Eure-et-Loir par rapport à la journée précédente. 
Je n'ai pour le moment pas l'explication. 
Soit un glissement de la donnée entre les 2 départements 🤔. 
Soit un simple correctif de leur part.