### PR TITLE
FIX ARS Normandie nombre de décès

### DIFF
--- a/agences-regionales-sante/normandie/2020-03-18.yaml
+++ b/agences-regionales-sante/normandie/2020-03-18.yaml
@@ -6,28 +6,33 @@ donneesRegionales:
   nom: Normandie
   code: REG-28
   casConfirmes: 208 # +34
-  deces: 3 
-  victimes:
-    - date: 2020-03-18
-      age: 75
-    - date: 2020-03-18
-      age: 65
+  deces: 3 # +2
   hospitalises: 45 # Pas de mise à jour
 donneesDepartementales:
   - nom: Manche
     code: DEP-50
     casConfirmes: 42 # +10 par rapport à hier
+    deces: 0 # Reprise fichier précédent
   - nom: Calvados
     code: DEP-14
     casConfirmes: 71 # +5 par rapport à hier
+    deces: 0 # Reprise fichier précédent
   - nom: Seine-Maritime
     code: DEP-76
     casConfirmes: 57 # + 18 par rapport à hier
+    deces: 3 # Reprise fichier précédent + 2 décès au CHI d’Elbeuf Louviers
     victimes:
-      - date: 2020-03-06
+      - date: 2020-03-18
+        age: 75
+        sexe: homme
+      - date: 2020-03-18
+        age: 65
+        sexe: homme
   - nom: Eure
     code: DEP-27
     casConfirmes: 29 # +0
+    deces: 0 # Reprise fichier précédent
   - nom: Orne
     code: DEP-61
     casConfirmes: 9 # +1
+    deces: 0 # Reprise fichier précédent

--- a/agences-regionales-sante/normandie/2020-03-18.yaml
+++ b/agences-regionales-sante/normandie/2020-03-18.yaml
@@ -20,12 +20,12 @@ donneesDepartementales:
   - nom: Seine-Maritime
     code: DEP-76
     casConfirmes: 57 # + 18 par rapport à hier
-    deces: 3 # Reprise fichier précédent + 2 décès au CHI d’Elbeuf Louviers
+    deces: 3 # Reprise fichier précédent + 2 décès au CHI d’Elbeuf Louviers (Seine-Martime)
     victimes:
-      - date: 2020-03-18
+      - date: 2020-03-18 # décédé au CHI d’Elbeuf Louviers (Seine-Martime mais couvrant aussi Eure)
         age: 75
         sexe: homme
-      - date: 2020-03-18
+      - date: 2020-03-18 # décédé au CHI d’Elbeuf Louviers (Seine-Martime mais couvrant aussi Eure)
         age: 65
         sexe: homme
   - nom: Eure

--- a/agences-regionales-sante/normandie/2020-03-19.yaml
+++ b/agences-regionales-sante/normandie/2020-03-19.yaml
@@ -7,21 +7,32 @@ donneesRegionales:
   nom: Normandie
   code: REG-28
   casConfirmes: 241 # +33
-  deces: 5 
+  deces: 5 # +2
   hospitalises: 46 # +1 par rapport à hier
 donneesDepartementales:
   - nom: Manche
     code: DEP-50
     casConfirmes: 44 # +2 par rapport à hier
+    deces: 0 # Reprise fichier précédent
   - nom: Calvados
     code: DEP-14
     casConfirmes: 76 # +5 par rapport à hier
+    deces: 0 # Reprise fichier précédent
   - nom: Seine-Maritime
     code: DEP-76
     casConfirmes: 77 # + 20 par rapport à hier
+    deces: 4 # Reprise fichier précédent + 1 décès au Havre
+    victimes:
+      - date: 2020-03-19
+        sexe: homme
   - nom: Eure
     code: DEP-27
     casConfirmes: 35 # +6
+    deces: 1 # Reprise fichier précédent + 1 décès à Evreux
+    victimes:
+      - date: 2020-03-19
+        sexe: homme
   - nom: Orne
     code: DEP-61
     casConfirmes: 9 # +0
+    deces: 0 # Reprise fichier précédent

--- a/agences-regionales-sante/normandie/2020-03-20.yaml
+++ b/agences-regionales-sante/normandie/2020-03-20.yaml
@@ -7,26 +7,37 @@ donneesRegionales:
   nom: Normandie
   code: REG-28
   casConfirmes: 287 # +46
-  deces: 7 
+  deces: 7 # +2
   hospitalises: 70
 donneesDepartementales:
   - nom: Manche
     code: DEP-50
     casConfirmes: 47 # +3 par rapport à hier
+    deces: 0 # Reprise fichier précédent
     hospitalises: 12
   - nom: Calvados
     code: DEP-14
     casConfirmes: 85 # +9 par rapport à hier
     hospitalises: 4
+    deces: 1 # Reprise fichier précédent + 1 décès à Caen
+    victimes:
+      - date: 2020-03-20
+        sexe: homme # age > 80
   - nom: Seine-Maritime
     code: DEP-76
     casConfirmes: 109 # +31 par rapport à hier
     hospitalises: 46
+    deces: 5 # Reprise fichier précédent + 1 décès à Elbeuf
+    victimes:
+      - date: 2020-03-20
+        sexe: homme # age > 80
   - nom: Eure
     code: DEP-27
     casConfirmes: 36 # +2
     hospitalises: 4
+    deces: 1 # Reprise fichier précédent
   - nom: Orne
     code: DEP-61
     casConfirmes: 10 # +1
     hospitalises: 4
+    deces: 0 # Reprise fichier précédent

--- a/agences-regionales-sante/normandie/2020-03-20.yaml
+++ b/agences-regionales-sante/normandie/2020-03-20.yaml
@@ -27,9 +27,9 @@ donneesDepartementales:
     code: DEP-76
     casConfirmes: 109 # +31 par rapport à hier
     hospitalises: 46
-    deces: 5 # Reprise fichier précédent + 1 décès à Elbeuf
+    deces: 5 # Reprise fichier précédent + 1 décès à Elbeuf (Seine-Martime)
     victimes:
-      - date: 2020-03-20
+      - date: 2020-03-20 # décédé à Elbeuf (probablement le CHI d’Elbeuf Louviers en Seine-Martime mais couvrant aussi Eure)
         sexe: homme # age > 80
   - nom: Eure
     code: DEP-27

--- a/agences-regionales-sante/normandie/2020-03-21.yaml
+++ b/agences-regionales-sante/normandie/2020-03-21.yaml
@@ -24,9 +24,9 @@ donneesDepartementales:
     code: DEP-76
     casConfirmes: 128 # +19 par rapport à hier
     hospitalises: 61
-    deces: 6 # Reprise fichier précédent + 1 décès à Elbeuf
+    deces: 6 # Reprise fichier précédent + 1 décès CH d'Elbeuf
     victimes:
-      - date: 2020-03-21
+      - date: 2020-03-21 # décédé au CH d'Elbeuf (probablement au CHI d’Elbeuf Louviers en Seine-Maritime mais couvrant aussi Eure)
         sexe: femme
         age: 73
   - nom: Eure

--- a/agences-regionales-sante/normandie/2020-03-21.yaml
+++ b/agences-regionales-sante/normandie/2020-03-21.yaml
@@ -14,19 +14,28 @@ donneesDepartementales:
     code: DEP-50
     casConfirmes: 63 # +16 par rapport à hier
     hospitalises: 17
+    deces: 0 # Reprise fichier précédent
   - nom: Calvados
     code: DEP-14
     casConfirmes: 99 # +14 par rapport à hier
     hospitalises: 9
+    deces: 1 # Reprise fichier précédent
   - nom: Seine-Maritime
     code: DEP-76
     casConfirmes: 128 # +19 par rapport à hier
     hospitalises: 61
+    deces: 6 # Reprise fichier précédent + 1 décès à Elbeuf
+    victimes:
+      - date: 2020-03-21
+        sexe: femme
+        age: 73
   - nom: Eure
     code: DEP-27
     casConfirmes: 40 # +4
     hospitalises: 7
+    deces: 0 # Reprise fichier précédent - 1 décès mis dans une autre région (utilisation de Santé Publique France pour déterminer le département)
   - nom: Orne
     code: DEP-61
     casConfirmes: 15 # +5
     hospitalises: 4
+    deces: 0 # Reprise fichier précédent

--- a/agences-regionales-sante/normandie/2020-03-22.yaml
+++ b/agences-regionales-sante/normandie/2020-03-22.yaml
@@ -24,7 +24,7 @@ donneesDepartementales:
     code: DEP-76
     casConfirmes: 170 # +42 par rapport à hier
     hospitalises: 71
-    deces: 8 # Reprise fichier précédent + 2 décès
+    deces: 8 # Reprise fichier précédent + 2 "personnes porteuses du coronavirus Covid-19 en Seine-Maritime"
     victimes:
       - age: 71
         sexe: homme

--- a/agences-regionales-sante/normandie/2020-03-22.yaml
+++ b/agences-regionales-sante/normandie/2020-03-22.yaml
@@ -14,24 +14,31 @@ donneesDepartementales:
     code: DEP-50
     casConfirmes: 87 # +24 par rapport à hier
     hospitalises: 19
+    deces: 0 # Reprise fichier précédent
   - nom: Calvados
     code: DEP-14
     casConfirmes: 129 # +30 par rapport à hier
     hospitalises: 20
+    deces: 1 # Reprise fichier précédent
   - nom: Seine-Maritime
     code: DEP-76
     casConfirmes: 170 # +42 par rapport à hier
     hospitalises: 71
+    deces: 8 # Reprise fichier précédent + 2 décès
     victimes:
       - age: 71
         sexe: homme
+        date: 2020-03-22
       - age: 82
         sexe: homme
+        date: 2020-03-22
   - nom: Eure
     code: DEP-27
     casConfirmes: 53 # +13
     hospitalises: 12
+    deces: 0 # Reprise fichier précédent
   - nom: Orne
     code: DEP-61
     casConfirmes: 23 # +8
     hospitalises: 4
+    deces: 0 # Reprise fichier précédent

--- a/agences-regionales-sante/normandie/2020-03-23.yaml
+++ b/agences-regionales-sante/normandie/2020-03-23.yaml
@@ -14,22 +14,28 @@ donneesDepartementales:
     code: DEP-50
     casConfirmes: 97 # +10 par rapport à hier
     hospitalises: 20
+    deces: 0 # Reprise fichier précédent
   - nom: Calvados
     code: DEP-14
     casConfirmes: 130 # +1 par rapport à hier
     hospitalises: 23
+    deces: 1 # Reprise fichier précédent
   - nom: Seine-Maritime
     code: DEP-76
     casConfirmes: 195 # +25 par rapport à hier
     hospitalises: 82
+    deces: 9 # Reprise fichier précédent + 1 décès
     victimes:
       - age: 83
         sexe: homme
+        date: 2020-03-23
   - nom: Eure
     code: DEP-27
     casConfirmes: 62 # +9
     hospitalises: 15
+    deces: 0 # Reprise fichier précédent
   - nom: Orne
     code: DEP-61
     casConfirmes: 27 # +4
     hospitalises: 6
+    deces: 0 # Reprise fichier précédent

--- a/agences-regionales-sante/normandie/2020-03-23.yaml
+++ b/agences-regionales-sante/normandie/2020-03-23.yaml
@@ -24,7 +24,7 @@ donneesDepartementales:
     code: DEP-76
     casConfirmes: 195 # +25 par rapport à hier
     hospitalises: 82
-    deces: 9 # Reprise fichier précédent + 1 décès
+    deces: 9 # Reprise fichier précédent + 1  "décès d’un homme de 83 ans porteur du coronavirus Covid-19 en Seine-Maritime
     victimes:
       - age: 83
         sexe: homme

--- a/agences-regionales-sante/normandie/2020-03-23.yaml
+++ b/agences-regionales-sante/normandie/2020-03-23.yaml
@@ -24,7 +24,7 @@ donneesDepartementales:
     code: DEP-76
     casConfirmes: 195 # +25 par rapport à hier
     hospitalises: 82
-    deces: 9 # Reprise fichier précédent + 1  "décès d’un homme de 83 ans porteur du coronavirus Covid-19 en Seine-Maritime
+    deces: 9 # Reprise fichier précédent + 1 "décès d’un homme de 83 ans porteur du coronavirus Covid-19 en Seine-Maritime"
     victimes:
       - age: 83
         sexe: homme

--- a/agences-regionales-sante/normandie/2020-03-24.yaml
+++ b/agences-regionales-sante/normandie/2020-03-24.yaml
@@ -15,22 +15,24 @@ donneesDepartementales:
     code: DEP-14
     casConfirmes: 147 # +17 par rapport à hier
     hospitalises: 25
+    deces: 1 # Reprise fichier précédent
   - nom: Eure
     code: DEP-27
     casConfirmes: 71 # +9
     hospitalises: 15
-    # +1 décès dans l’Eure
+    deces: 1 # Reprise fichier précédent + 1 décès
   - nom: Manche
     code: DEP-50
     casConfirmes: 107 # +10 par rapport à hier
     hospitalises: 15
-    # +2 décès dans la Manche
+    deces: 2 # Reprise fichier précédent + 2 décès
   - nom: Orne
     code: DEP-61
     casConfirmes: 28 # +1
     hospitalises: 9
+    deces: 0 # Reprise fichier précédent
   - nom: Seine-Maritime
     code: DEP-76
     casConfirmes: 233 # +38 par rapport à hier
     hospitalises: 97
-    # +3 décès dans la Seine-Maritime
+    deces: 12 # Reprise fichier précédent + 3 décès

--- a/agences-regionales-sante/normandie/2020-03-24.yaml
+++ b/agences-regionales-sante/normandie/2020-03-24.yaml
@@ -20,12 +20,12 @@ donneesDepartementales:
     code: DEP-27
     casConfirmes: 71 # +9
     hospitalises: 15
-    deces: 1 # Reprise fichier précédent + 1 décès
+    deces: 1 # 0 décès dans le fichier précédent + 1 décès
   - nom: Manche
     code: DEP-50
     casConfirmes: 107 # +10 par rapport à hier
     hospitalises: 15
-    deces: 2 # Reprise fichier précédent + 2 décès
+    deces: 2 # 0 décès dans le fichier précédent + 2 décès
   - nom: Orne
     code: DEP-61
     casConfirmes: 28 # +1
@@ -35,4 +35,4 @@ donneesDepartementales:
     code: DEP-76
     casConfirmes: 233 # +38 par rapport à hier
     hospitalises: 97
-    deces: 12 # Reprise fichier précédent + 3 décès
+    deces: 12 # 9 décès repris du fichier précédent + 3 décès


### PR DESCRIPTION
Reprise des publications pour attribuer les décès par département.

Usage de Santé Publique France pour déterminer que c'était dans l'Eure qu'il fallait enlever un décès le 21 mars