### PR TITLE
ADD ARS LA Réunion du 26/03

### DIFF
--- a/agences-regionales-sante/reunion/2020-03-26.yaml
+++ b/agences-regionales-sante/reunion/2020-03-26.yaml
@@ -6,10 +6,12 @@ source:
 donneesRegionales:
   nom: La Réunion
   code: COM-974
-  casConfirmes: 108 # hier 94 cas importés / 7 transmissions locales / 7 transmissions locales avec voyageurs non diag ou personnes en contact de personnes confirmées
+  casConfirmes: 135 # hier 94 cas importés / 7 transmissions locales / 7 transmissions locales avec voyageurs non diag ou personnes en contact de personnes confirmées / 27 cas sont toujours en investigation
   reanimation: 4
+  
   #url2 : https://www.lareunion.ars.sante.fr/system/files/2020-03/2020-03-26_CP_135%20cas%20avérés.pdf
   #archive2 : https://www.lareunion.ars.sante.fr/system/files/2020-03/2020-03-26_CP_135%20cas%20avérés.pdf
+  
   #Détails des cas par tranches d'age
   #4 cas sont des mineurs (5, 11, 17)
   #56 cas ont moins de 50 ans

--- a/agences-regionales-sante/reunion/2020-03-26.yaml
+++ b/agences-regionales-sante/reunion/2020-03-26.yaml
@@ -1,0 +1,18 @@
+date: 2020-03-26
+source:
+  nom: ARS La Réunion
+  url: https://www.lareunion.ars.sante.fr/coronavirus-covid-19-la-reunion-20-nouveaux-cas-confirmes
+  archive: https://web.archive.org/web/20200326173657/https://www.lareunion.ars.sante.fr/coronavirus-covid-19-la-reunion-20-nouveaux-cas-confirmes
+donneesRegionales:
+  nom: La Réunion
+  code: COM-974
+  casConfirmes: 108 # hier 94 cas importés / 7 transmissions locales / 7 transmissions locales avec voyageurs non diag ou personnes en contact de personnes confirmées
+  reanimation: 4
+  #url2 : https://www.lareunion.ars.sante.fr/system/files/2020-03/2020-03-26_CP_135%20cas%20avérés.pdf
+  #archive2 : https://www.lareunion.ars.sante.fr/system/files/2020-03/2020-03-26_CP_135%20cas%20avérés.pdf
+  #Détails des cas par tranches d'age
+  #4 cas sont des mineurs (5, 11, 17)
+  #56 cas ont moins de 50 ans
+  #30 cas ont entre 50 et 65 ans
+  #18 cas ont plus de 65 ans (il est écrit moins mais c'est plus) 
+  #27 cas sont toujours en investigation

--- a/agences-regionales-sante/reunion/2020-03-26.yaml
+++ b/agences-regionales-sante/reunion/2020-03-26.yaml
@@ -1,6 +1,7 @@
 date: 2020-03-26
 source:
   nom: ARS La Réunion
+  # Attention, la source indique "ce jeudi 25 mars", mais à priori c'est une erreur. Il semblerait que ce soit les données du 26/03
   url: https://www.lareunion.ars.sante.fr/coronavirus-covid-19-la-reunion-20-nouveaux-cas-confirmes
   archive: https://web.archive.org/web/20200326173657/https://www.lareunion.ars.sante.fr/coronavirus-covid-19-la-reunion-20-nouveaux-cas-confirmes
 donneesRegionales:


### PR DESCRIPTION
Question : D'un communiqué à l'autre les "en cours d'investigation" sont comptés (celui du 25 je suppose qu'ils sont inclus) mais dans celui du 26 il ne le sont plus.
Le vocabulaire a également changé. 
La ou on parle de "cas" on dirait que c'est en global (inclus confirmés et en investigation).
La ou on parle de "cas investigués" ceux en cours ne sont plus inclus.

Du coup ma question (désolé pour cette énième question) c'est comment on compte ces personnes dans les données ?

Je ne me vois pas dans ce genre de cas compté 135 personne en cas confirmés étant donné que 27 semblent en cours d'investigation.