### PR TITLE
ADD ARS Pays de la Loire 26/03

### DIFF
--- a/agences-regionales-sante/pays-de-la-loire/2020-03-26.yaml
+++ b/agences-regionales-sante/pays-de-la-loire/2020-03-26.yaml
@@ -1,0 +1,12 @@
+date: "2020-03-26"
+source:
+  nom: ARS Pays de la Loire
+  url: https://www.pays-de-la-loire.ars.sante.fr/system/files/2020-03/2020-03-26-bulletin%20information%20COVID-19_1.pdf
+  archive: /web/20200326201030/https://www.pays-de-la-loire.ars.sante.fr/system/files/2020-03/2020-03-26-bulletin%20information%20COVID-19_1.pdf
+donneesRegionales:
+  nom: Pays de la Loire
+  code: REG-52
+  casConfirmes: 459
+  reanimation: 69 # 49 du précédent bulletin et 20 patients accueillis par le train sanitaire
+  deces: 31 # moyenne d'âge 86 ans, 24 décès en hôpitaux et 7 en EHPAD
+  gueris: 119 # retours à domicile


### PR DESCRIPTION
Discussions :
- Pour les réanimations j'ai inclu les cas non confirmés comme dans [le fichier de la veille](https://github.com/opencovid19-fr/data/blob/master/agences-regionales-sante/pays-de-la-loire/2020-03-25.yaml)
- Pour les décès j'ai inclu ceux des EHPAD
- Je n'ai pas détaillé les décès par département tout comme [le fichier de la veille](https://github.com/opencovid19-fr/data/blob/master/agences-regionales-sante/pays-de-la-loire/2020-03-25.yaml). A titre personnel je pense qu'on pourrait attribuer les décès au département du CHU où s'est produit le décès mais il semble que cela va à l'encontre du [Readme de ce dossier](https://github.com/opencovid19-fr/data/blob/master/agences-regionales-sante/pays-de-la-loire/README.md).