### PR TITLE
ADD ARS Centre Val de Loire du 26/03

### DIFF
--- a/agences-regionales-sante/centre-val-de-loire/2020-03-26.yaml
+++ b/agences-regionales-sante/centre-val-de-loire/2020-03-26.yaml
@@ -1,0 +1,38 @@
+date: 2020-03-26
+source:
+  nom: ARS Centre-Val de Loire
+  url: https://www.centre-val-de-loire.ars.sante.fr/system/files/2020-03/2020-03-26-bulletin%20information%20COVID-19_0.pdf
+  archive: https://web.archive.org/web/20200326203535/https://www.centre-val-de-loire.ars.sante.fr/system/files/2020-03/2020-03-26-bulletin%20information%20COVID-19_0.pdf
+donneesRegionales:
+  nom: Centre-Val de Loire
+  code: REG-24
+  casConfirmes: 645
+  deces: 20
+  reanimation: 67
+donneesDepartementales:
+  - nom: Cher
+    code: DEP-18
+    casConfirmes: 25
+    deces: 1
+  - nom: Eure-et-Loir
+    code: DEP-28
+    casConfirmes: 104
+    deces: 8
+  - nom: Indre
+    code: DEP-36
+    casConfirmes: 80
+    deces: 5
+  - nom: Indre-et-Loire
+    code: DEP-37
+    casConfirmes: 123
+    deces: 3
+  - nom: Loir-et-Cher
+    code: DEP-41
+    casConfirmes: 55
+    deces: 0
+  - nom: Loiret
+    code: DEP-45
+    casConfirmes: 258
+    deces: 3
+    
+ #A compter de demain, le nombre de cas confirmés ne sera plus communiqué : il n’est plus un marqueur significatif de la présence du virus.


### PR DESCRIPTION
Comme mis en commentaire. A compter de demain le nombre de cas ne sera plus communiqués pour le Centre Val de Loire.